### PR TITLE
Correct location of devtools property.

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -5,11 +5,11 @@
  {:app  {:target     :browser
          :output-dir "public/js"
          :asset-path "js"
-         :modules {:main {:entries [app.core]}
-                   :devtools {:before-load app.core/stop
-                              :after-load app.core/start
-                              :http-root "public"
-                              :http-port 8020}}}
+         :modules {:main {:entries [app.core]}}
+         :devtools {:before-load app.core/stop
+                    :after-load app.core/start
+                    :http-root "public"
+                    :http-port 8020}}
   :lib {:target     :node-library
         :output-dir "public/lib"
         :output-to "public/lib/library.js"


### PR DESCRIPTION
Making :devtools a sibling of :modules rather than a child is required for the web server to start, addressing issue #1.